### PR TITLE
[CET-1526] Support for team overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cortexapps/backstage-plugin-extensions",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Extensions to Cortex Backstage Plugins",
   "repository": "github:cortexapps/backstage-plugin-extensions",
   "author": "Nikhil Unni <nikhil.unni3000@gmail.com>",

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -130,11 +130,46 @@ export type CortexYaml = {
 
 export type CustomMapping = (entity: Entity) => Partial<CortexYaml>;
 
+interface EmailMember {
+  name: string;
+  email: string;
+  description?: string;
+}
+
+interface Team {
+  teamTag: string;
+  name: string;
+  shortDescription?: string;
+  fullDescription?: string;
+  links?: {
+    name: string;
+    type: string;
+    url: string;
+    description?: string;
+  }[];
+  slackChannels?: {
+    name: string;
+    notificationsEnabled: boolean;
+  }[];
+  emailMembers?: EmailMember[];
+  additionalMembers?: EmailMember[];
+}
+
+interface Relationship {
+  parentTeamTag: string;
+  childTeamTag: string;
+}
+
+export interface TeamOverrides {
+  teams: Team[];
+  relationships: Relationship[];
+}
+
 export interface ExtensionApi {
   /**
    * Additional filters on Entities for scorecards and initiatives
    */
-  getAdditionalFilters(): Promise<EntityFilterGroup[]>;
+  getAdditionalFilters?(): Promise<EntityFilterGroup[]>;
 
   /**
    * Override default mapping to Cortex YAMLs. Can be used to map custom fields without the need
@@ -143,5 +178,11 @@ export interface ExtensionApi {
    * List of Cortex annotations can be found here: https://docs.getcortexapp.com/service-descriptor/
    *
    */
-  getCustomMappings(): Promise<CustomMapping[]>;
+  getCustomMappings?(): Promise<CustomMapping[]>;
+
+  /**
+   * Override default teams and team hierarchies in Cortex.
+   * Can be used to fine tune where team information should come from, as well as particular team metadata.
+   */
+  getTeamOverrides?(entities: Entity[]): Promise<TeamOverrides>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,5 +18,6 @@ export type {
   ExtensionApi,
   CortexYaml,
   CustomMapping,
+  TeamOverrides,
 } from './extensionApi';
 export type { EntityFilterGroup } from './filters';


### PR DESCRIPTION
Adds new team overrides to plugin extensions. Cortex has a default way of mapping `Group`s to Cortex teams -- but this will allow you to specify how you want teams / team hierarchies to be mapped as an override