### PR TITLE
[CET-3019] Extension to alter default sort order of Scorecards

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,9 @@
   "name": "@cortexapps/backstage-plugin-extensions",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Extensions to Cortex Backstage Plugins",
   "repository": "github:cortexapps/backstage-plugin-extensions",
-  "author": "Nikhil Unni <nikhil.unni3000@gmail.com>",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -176,11 +176,57 @@ export interface TeamOverrides {
   relationships: Relationship[];
 }
 
+export interface Rule {
+  id: number;
+  expression: string;
+  title?: string;
+  description?: string;
+  failureMessage?: string;
+  dateCreated?: string;
+  weight: number;
+}
+
+export interface ServiceGroup {
+  id: string;
+  tag: string;
+}
+
+export interface Scorecard {
+  creator: {
+    name: string;
+    email: string;
+  };
+  id: number;
+  name: string;
+  description?: string;
+  rules: Rule[];
+  tags: ServiceGroup[];
+  excludedTags: ServiceGroup[];
+  filterQuery?: string;
+  nextUpdated?: string;
+}
+
+export interface UiExtensions {
+  scorecards?: {
+    /**
+     * Override default sort order of Scorecards in both the global and entity list view of Scorecards.
+     */
+    sortOrder?: {
+      compareFn: (a: Scorecard, b: Scorecard) => number;
+    }
+  }
+}
+
 export interface ExtensionApi {
   /**
    * Additional filters on Entities for scorecards and initiatives
    */
   getAdditionalFilters?(): Promise<EntityFilterGroup[]>;
+
+  /**
+   * Override default UI for @cortexapps/backstage-plugin
+   */
+  getUiExtensions?(): Promise<UiExtensions>;
 
   /**
    * Override default mapping to Cortex YAMLs. Can be used to map custom fields without the need

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -186,7 +186,7 @@ export interface Rule {
   weight: number;
 }
 
-export interface ServiceGroup {
+export interface Group {
   id: string;
   tag: string;
 }
@@ -200,8 +200,8 @@ export interface Scorecard {
   name: string;
   description?: string;
   rules: Rule[];
-  tags: ServiceGroup[];
-  excludedTags: ServiceGroup[];
+  tags: Group[];
+  excludedTags: Group[];
   filterQuery?: string;
   nextUpdated?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,13 @@
  */
 
 export type {
-  ExtensionApi,
   CortexYaml,
   CustomMapping,
+  ExtensionApi,
+  Rule,
+  Scorecard,
+  ServiceGroup,
   TeamOverrides,
+  UiExtensions,
 } from './extensionApi';
 export type { EntityFilterGroup } from './filters';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export type {
   ExtensionApi,
   Rule,
   Scorecard,
-  ServiceGroup,
+  Group,
   TeamOverrides,
   UiExtensions,
 } from './extensionApi';


### PR DESCRIPTION
Right now the default is to sort alphabetically whenever listing Scorecards.
This extension will enable customers to provide their own custom sort order.