### PR TITLE
[CET-3177] Support for optional help page, starting with links

### DIFF
--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -206,6 +206,16 @@ export interface Scorecard {
   nextUpdated?: string;
 }
 
+export interface HelpPageLink {
+  name: string;
+  url: string;
+  description?: string;
+}
+
+export interface HelpPageDisplayOptions {
+  links?: HelpPageLink[];
+}
+
 export interface UiExtensions {
   scorecards?: {
     /**
@@ -219,9 +229,7 @@ export interface UiExtensions {
   /**
    * Add quick links to an optional help page.
    */
-  helpPage?: {
-    links?: [{ name: string; url: string; description?: string; }];
-  };
+  helpPage?: HelpPageDisplayOptions;
 }
 
 export interface ExtensionApi {

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -214,14 +214,14 @@ export interface UiExtensions {
     sortOrder?: {
       compareFn: (a: Scorecard, b: Scorecard) => number;
     }
-  },
+  };
 
   /**
    * Add quick links to an optional help page.
    */
   helpPage?: {
     links?: [{ name: string; url: string; description?: string; }];
-  }
+  };
 }
 
 export interface ExtensionApi {

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -214,6 +214,13 @@ export interface UiExtensions {
     sortOrder?: {
       compareFn: (a: Scorecard, b: Scorecard) => number;
     }
+  },
+
+  /**
+   * Add quick links to an optional help page.
+   */
+  helpPage?: {
+    links?: [{ name: string; url: string; description?: string; }];
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ export type {
   Scorecard,
   Group,
   TeamOverrides,
+  HelpPageDisplayOptions,
+  HelpPageLink,
   UiExtensions,
 } from './extensionApi';
 export type { EntityFilterGroup } from './filters';


### PR DESCRIPTION
Ability for users to define links they'd like to display in a new, optional help page for the plugin.