### PR TITLE
[CET-4196] Extension function to limit which entities are sent over during sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cortexapps/backstage-plugin-extensions",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "version": "0.0.18",
+  "version": "0.0.20",
   "description": "Extensions to Cortex Backstage Plugins",
   "repository": "github:cortexapps/backstage-plugin-extensions",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cortexapps/backstage-plugin-extensions",
   "main": "src/index.ts",
   "types": "src/index.ts",
-  "version": "0.0.20",
+  "version": "0.0.19",
   "description": "Extensions to Cortex Backstage Plugins",
   "repository": "github:cortexapps/backstage-plugin-extensions",
   "license": "Apache-2.0",

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -212,6 +212,20 @@ export interface HelpPageLink {
   description?: string;
 }
 
+export interface EntityFilter {
+  /**
+   * Limits entity kinds that are queried.
+   * Can be used to reduce total number of entities that are in loaded in memory
+   * before pushing to Cortex
+   */
+  kinds?: string[];
+  /**
+   * On top of the kinds filter, can be used to filter on a per-entity basis after all
+   * entities to potentially send have been loaded in memory.
+   */
+  entityFilter?: (entity: Entity) => boolean;
+}
+
 export interface HelpPageDisplayOptions {
   links?: HelpPageLink[];
 }
@@ -264,4 +278,12 @@ export interface ExtensionApi {
    * Can be used to fine tune where team information should come from, as well as particular team metadata.
    */
   getTeamOverrides?(entities: Entity[]): Promise<TeamOverrides>;
+
+  /**
+   * Optional entity filter for syncs between Backstage and Cortex.
+   *
+   * By default, Backstage will send every entity manifest to Cortex,
+   * but this allows users to limit which entities are sent over.
+   */
+  getEntityFilter?(): Promise<EntityFilter>;
 }

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -274,16 +274,16 @@ export interface ExtensionApi {
   getCustomMappings?(): Promise<CustomMapping[]>;
 
   /**
-   * Override default teams and team hierarchies in Cortex.
-   * Can be used to fine tune where team information should come from, as well as particular team metadata.
-   */
-  getTeamOverrides?(entities: Entity[]): Promise<TeamOverrides>;
-
-  /**
    * Optional entity filter for syncs between Backstage and Cortex.
    *
    * By default, Backstage will send every entity manifest to Cortex,
    * but this allows users to limit which entities are sent over.
    */
-  getEntityFilter?(): Promise<EntityFilter>;
+  getSyncEntityFilter?(): Promise<EntityFilter>;
+
+  /**
+   * Override default teams and team hierarchies in Cortex.
+   * Can be used to fine tune where team information should come from, as well as particular team metadata.
+   */
+  getTeamOverrides?(entities: Entity[]): Promise<TeamOverrides>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@
 export type {
   CortexYaml,
   CustomMapping,
+  EntityFilter,
   ExtensionApi,
   Rule,
   Scorecard,


### PR DESCRIPTION
Give users the option to limit which entities are sent over to Cortex for the YAML conversion / sync -- we're sending way too much data for larger instances of Backstage, and this will give some configuration power back to the users if there's completely unused data being sent to Cortex