### PR TITLE
fix(jira): added missing fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Extensions to Cortex Backstage Plugins",
   "repository": "github:cortexapps/backstage-plugin-extensions",
   "license": "Apache-2.0",

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -124,7 +124,9 @@ export type CortexYaml = {
   };
   "x-cortex-issues"?: {
     jira?: {
+      components: string[];
       labels: string[];
+      projects: string[];
     };
   };
   "x-cortex-sentry"?: {


### PR DESCRIPTION
This PR adds support for two fields to be used with the Jira integration (from https://docs.cortex.io/docs/reference/integrations/jira#editing-the-entity-descriptor)